### PR TITLE
chore: Update to Go 1.17 (from 1.16)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-go@v1.1.3
       with:
-        go-version: "1.16.x"
+        go-version: "1.17.x"
     - uses: actions/setup-node@v1
       with:
         node-version: '12'
@@ -27,7 +27,7 @@ jobs:
         node-version: '12'
     - uses: actions/setup-go@v1.1.3
       with:
-        go-version: "1.16.x"
+        go-version: "1.17.x"
     - name: Create package
       run: sudo bash -c "wget https://github.com/goreleaser/goreleaser/releases/download/v0.138.0/goreleaser_amd64.deb && dpkg -i goreleaser_amd64.deb && goreleaser release --snapshot"
     - uses: jakejarvis/s3-sync-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.13 AS gobuilder
+FROM golang:1.17-alpine3.13 AS gobuilder
 RUN apk add --no-cache gcc libc-dev git sqlite-dev
 COPY . /src
 WORKDIR /src/cmd/webmentiond


### PR DESCRIPTION
Closes #44 

Similar to previous upgrade from 1.15 to 1.16 here: https://github.com/zerok/webmentiond/commit/a617670995e92965cbf0823f4191bcf80bb0e452