### PR TITLE
Add pipeline for tags (releases)

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,30 @@
+name: Tag
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-go@v4
+      with:
+        go-version: "1.21.0"
+    - name: Log into DockerHub
+      run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+    - name: Run dagger
+      env:
+        GIT_COMMIT_ID: ${{ github.sha }}
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_S3_ENDPOINT: "https://ams3.digitaloceanspaces.com"
+        AWS_REGION: ""
+        SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        RELEASE_VERSION: ${{ github.ref_name }}
+      run: go run ./ci --build --publish


### PR DESCRIPTION
This will generate a new release if a tag is pushed following the `v*` pattern. In the future we might move even the tagging into a workflow but for now this should be enough.